### PR TITLE
Add missing newline when adding apphance to project.properties

### DIFF
--- a/src/main/groovy/com/apphance/flow/plugins/android/apphance/tasks/AddApphanceToAndroid.groovy
+++ b/src/main/groovy/com/apphance/flow/plugins/android/apphance/tasks/AddApphanceToAndroid.groovy
@@ -215,7 +215,7 @@ class AddApphanceToAndroid {
         assert projectProperties.exists()
         List<String> lines = projectProperties.readLines()
         int libSize = maxLibNumber(lines)
-        projectProperties << "android.library.reference.${libSize + 1}=libs/apphance-library-${apphanceVersion}"
+        projectProperties << "\nandroid.library.reference.${libSize + 1}=libs/apphance-library-${apphanceVersion}"
     }
 
     int maxLibNumber(List<String> lines) {


### PR DESCRIPTION
When Apphance Flow modifies project.properties to add reference to Apphance, it does not add new line to this file
